### PR TITLE
Add single quotes around keys in js_parameters

### DIFF
--- a/lib/google_visualr/param_helpers.rb
+++ b/lib/google_visualr/param_helpers.rb
@@ -12,7 +12,7 @@ module GoogleVisualr
     def js_parameters(options)
       return "" if options.nil?
 
-      attributes = options.collect { |(key, value)| "#{key}: #{typecast(value)}" }
+      attributes = options.collect { |(key, value)| "'#{key}': #{typecast(value)}" }
       "{" + attributes.join(", ") + "}"
     end
 


### PR DESCRIPTION
Options like legend.position are not useable because they key will break js
