### PR TITLE
allow decoupling of chart name and class name

### DIFF
--- a/lib/google_visualr/base_chart.rb
+++ b/lib/google_visualr/base_chart.rb
@@ -19,6 +19,10 @@ module GoogleVisualr
       @options = stringify_keys!(options)
     end
 
+    def chart_name
+      class_name
+    end
+
     # Generates JavaScript and renders the Google Chart in the final HTML output.
     #
     # Parameters:
@@ -27,7 +31,7 @@ module GoogleVisualr
       js  = "\n<script type='text/javascript'>"
       js << "\n  google.load('visualization','1', {packages: ['#{package_name}'], callback: function() {"
       js << "\n    #{@data_table.to_js}"
-      js << "\n    var chart = new google.visualization.#{class_name}(document.getElementById('#{element_id}'));"
+      js << "\n    var chart = new google.visualization.#{chart_name}(document.getElementById('#{element_id}'));"
       js << "\n    chart.draw(data_table, #{js_parameters(@options)});"
       js << "\n  }});"
       js << "\n</script>"


### PR DESCRIPTION
From my comment in issue #38 - 

> I wanted to override individual chart types (e.g. GoogleVisualr::Interactive::BarChart) to carry some extra data around before rendering. In my case I made a "ClickableBarChart". This also required redefining BaseChart.to_js, because it uses class_name to specify the Google chart type. I propose we have something like "chart_name" as a property, and in BaseChart that simply returns class_name...but in subclasses this could be overridden to be whatever was necessary.

The attached code implements this...
