### PR TITLE
Update lib/google_visualr/base_chart.rb

### DIFF
--- a/lib/google_visualr/base_chart.rb
+++ b/lib/google_visualr/base_chart.rb
@@ -37,10 +37,10 @@ module GoogleVisualr
       js << "\n  google.load('visualization','1', {packages: ['#{package_name}'], callback: function() {"
       js << "\n    #{@data_table.to_js}"
       js << "\n    var chart = new google.visualization.#{chart_name}(document.getElementById('#{element_id}'));"
-      js << "\n    chart.draw(data_table, #{js_parameters(@options)});"
       @listeners.each do |listener|
         js << "\n    google.visualization.events.addListener(chart, '#{listener[:event]}', #{listener[:callback]});"
       end
+      js << "\n    chart.draw(data_table, #{js_parameters(@options)});"
       js << "\n  }});"
       js << "\n</script>"
       js


### PR DESCRIPTION
The event registration happens after the `draw` call. Because of this `ready` events are never triggered.
Changed the order of event registration and `draw` call to address this issue.  
