### PR TITLE
DataTable: Accept BigDecimal as number

### DIFF
--- a/lib/google_visualr/data_table.rb
+++ b/lib/google_visualr/data_table.rb
@@ -243,7 +243,7 @@ module GoogleVisualr
         when type == "string"
           raise ArgumentError, "cell value '#{v}' is not a String", caller              unless v.is_a?(String)
         when type == "number"
-          raise ArgumentError, "cell value '#{v}' is not an Integer or a Float", caller unless v.is_a?(Integer)   || v.is_a?(Float)
+          raise ArgumentError, "cell value '#{v}' is not an Integer, Float or BigDecimal", caller unless v.is_a?(Integer) || v.is_a?(Float) || v.is_a?(BigDecimal)
         when type == "boolean"
           raise ArgumentError, "cell value '#{v}' is not a Boolean", caller             unless v.is_a?(TrueClass) || v.is_a?(FalseClass)
         when type == 'datetime'

--- a/spec/google_visualr/data_table_spec.rb
+++ b/spec/google_visualr/data_table_spec.rb
@@ -205,6 +205,12 @@ describe GoogleVisualr::DataTable do
         it "raises an exception if value is not date" do
           assert_raises_exception(4, 'ABCD')
         end
+        
+        it "accepts BigDecimal as number" do
+          expect {
+            dt.set_cell(0, 1, BigDecimal.new(42))
+          }.to_not raise_exception(ArgumentError)
+        end
       end
 
       it "accepts 'nil' for all column types" do


### PR DESCRIPTION
In addition to Integer and Float, the DataTable should accept BigDecimal as number, too.
