### PR TITLE
Very minor pull request: changing API call from http to https

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -41,7 +41,7 @@ For detailed documentation and advanced implementations, please refer to the {Go
 
 In your Rails layout, load Google Ajax API in the head tag, at the very top.
 
-  <script src='http://www.google.com/jsapi'></script>
+  <script src='https://www.google.com/jsapi'></script>
 
 In your Rails controller, initialize a GoogleVisualr::DataTable object with an empty constructor.
 


### PR DESCRIPTION
Changing from http to https allows google-visualr to correctly load in Heroku. See [here.](http://stackoverflow.com/questions/13748379/google-visualization-not-appearing-in-heroku-production)
