### PR TITLE
Adds ability to generate Material charts when applicable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    google_visualr (2.4.0)
+    google_visualr (2.4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/google_visualr/app/helpers/view_helper.rb
+++ b/lib/google_visualr/app/helpers/view_helper.rb
@@ -9,7 +9,13 @@ module GoogleVisualr
 
       def render_chart(chart, dom, options={})
         script_tag = options.fetch(:script_tag) { true }
-        if script_tag
+
+        # render material based charts
+        is_material_chart = options.fetch(:material) { false }
+
+        if is_material_chart
+          chart.to_material_js(dom).html_safe
+        elsif script_tag
           chart.to_js(dom).html_safe
         else
           html = ""

--- a/lib/google_visualr/base_chart.rb
+++ b/lib/google_visualr/base_chart.rb
@@ -72,7 +72,15 @@ module GoogleVisualr
 
     # material js option
     def material_package_name
-      chart_name.gsub("Chart","")
+      chart = chart_name.gsub("Chart","")
+      
+      # column chart uses the "Bar" namespace
+      # https://google-developers.appspot.com/chart/interactive/docs/gallery/columnchart#Material
+      if chart == "Column"
+        chart =  "Bar"
+      end
+
+      return chart
     end
 
     def to_material_js(element_id)

--- a/lib/google_visualr/base_chart.rb
+++ b/lib/google_visualr/base_chart.rb
@@ -104,7 +104,7 @@ module GoogleVisualr
       @listeners.each do |listener|
         js << "\n    google.visualization.events.addListener(chart, '#{listener[:event]}', #{listener[:callback]});"
       end
-      js << "\n    chart.draw(data_table, #{js_parameters(@options)});"
+      js << "\n    chart.draw(data_table, google.charts.#{material_package_name}.convertOptions(#{js_parameters(@options)}));"
       js << "\n  };"
       js
     end

--- a/lib/google_visualr/base_chart.rb
+++ b/lib/google_visualr/base_chart.rb
@@ -69,6 +69,38 @@ module GoogleVisualr
       js << "\n  };"
       js
     end
+
+    # material js option
+    def material_package_name
+      chart_name.gsub("Chart","")
+    end
+
+    def to_material_js(element_id)
+      js =  ""
+      js << "\n<script type='text/javascript'>"
+      js << load_material_js(element_id)
+      js << draw_material_js(element_id)
+      js << "\n</script>"
+      js
+    end
+
+    def load_material_js(element_id)
+      "\n  google.load('visualization','1.1', {packages: ['#{material_package_name.downcase}'], callback: #{chart_function_name(element_id)}});"
+    end
+
+    def draw_material_js(element_id)
+      js = ""
+      js << "\n  function #{chart_function_name(element_id)}() {"
+      js << "\n    #{@data_table.to_js}"
+      js << "\n    var chart = new google.charts.#{material_package_name}(document.getElementById('#{element_id}'));"
+      @listeners.each do |listener|
+        js << "\n    google.visualization.events.addListener(chart, '#{listener[:event]}', #{listener[:callback]});"
+      end
+      js << "\n    chart.draw(data_table, #{js_parameters(@options)});"
+      js << "\n  };"
+      js
+    end
+    # end material js option
   end
 
 end

--- a/lib/google_visualr/version.rb
+++ b/lib/google_visualr/version.rb
@@ -1,3 +1,3 @@
 module GoogleVisualr
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end


### PR DESCRIPTION
By passing in `material: true` to the render_chart helper, this will render the "Material" style google graphs.

https://google-developers.appspot.com/chart/interactive/docs/gallery/scatterchart#Material

**Example usage:**
`<%= render_chart(@chart, 'scatterchart_material', {material: true}) %>`

Not all graphs are Material enabled so it will be up to the developer to determine if this option can be used.