### PR TITLE
Adds locale option as described in..

### DIFF
--- a/lib/google_visualr.rb
+++ b/lib/google_visualr.rb
@@ -14,31 +14,33 @@ require "#{lib_path}/google_visualr/formatters"
 # Interactive Charts
 
 ## Main
+require "#{lib_path}/google_visualr/interactive/annotated_time_line"
+require "#{lib_path}/google_visualr/interactive/annotation_chart"
 require "#{lib_path}/google_visualr/interactive/area_chart"
 require "#{lib_path}/google_visualr/interactive/bar_chart"
 require "#{lib_path}/google_visualr/interactive/bubble_chart"
+require "#{lib_path}/google_visualr/interactive/calendar"
 require "#{lib_path}/google_visualr/interactive/candlestick_chart"
 require "#{lib_path}/google_visualr/interactive/column_chart"
 require "#{lib_path}/google_visualr/interactive/combo_chart"
+require "#{lib_path}/google_visualr/interactive/gantt_chart"
 require "#{lib_path}/google_visualr/interactive/gauge"
 require "#{lib_path}/google_visualr/interactive/geo_chart"
 require "#{lib_path}/google_visualr/interactive/geo_map"
 require "#{lib_path}/google_visualr/interactive/histogram"
-require "#{lib_path}/google_visualr/interactive/line_chart"
-require "#{lib_path}/google_visualr/interactive/pie_chart"
-require "#{lib_path}/google_visualr/interactive/scatter_chart"
-require "#{lib_path}/google_visualr/interactive/stepped_area_chart"
-require "#{lib_path}/google_visualr/interactive/table"
-require "#{lib_path}/google_visualr/interactive/tree_map"
-
-
-## Additional
-require "#{lib_path}/google_visualr/interactive/annotated_time_line"
 require "#{lib_path}/google_visualr/interactive/intensity_map"
+require "#{lib_path}/google_visualr/interactive/line_chart"
 require "#{lib_path}/google_visualr/interactive/map"
 require "#{lib_path}/google_visualr/interactive/motion_chart"
 require "#{lib_path}/google_visualr/interactive/org_chart"
+require "#{lib_path}/google_visualr/interactive/pie_chart"
+require "#{lib_path}/google_visualr/interactive/sankey"
+require "#{lib_path}/google_visualr/interactive/scatter_chart"
+require "#{lib_path}/google_visualr/interactive/stepped_area_chart"
+require "#{lib_path}/google_visualr/interactive/table"
 require "#{lib_path}/google_visualr/interactive/timeline"
+require "#{lib_path}/google_visualr/interactive/tree_map"
+require "#{lib_path}/google_visualr/interactive/word_tree"
 
 # Image Charts
 require "#{lib_path}/google_visualr/image/spark_line"

--- a/lib/google_visualr/base_chart.rb
+++ b/lib/google_visualr/base_chart.rb
@@ -5,12 +5,13 @@ module GoogleVisualr
 
     DEFAULT_VERSION = "1.0".freeze
 
-    attr_accessor :data_table, :listeners, :version, :material
+    attr_accessor :data_table, :listeners, :version, :language, :material
 
     def initialize(data_table, options={})
       @data_table  = data_table
       @listeners   = []
       @version     = options.delete(:version)  || DEFAULT_VERSION
+      @language    = options.delete(:language) || "en"
       @material    = options.delete(:material) || false
       send(:options=, options)
     end
@@ -73,7 +74,7 @@ module GoogleVisualr
     # Parameters:
     #  *div_id            [Required] The ID of the DIV element that the Google Chart should be rendered in.
     def load_js(element_id)
-      "\n  google.load('visualization','#{version}', {packages: ['#{package_name}'], callback: #{chart_function_name(element_id)}});"
+      "\n  google.load('visualization', '#{version}', {packages: ['#{package_name}'], language: '#{language}', callback: #{chart_function_name(element_id)}});"
     end
 
     # Generates JavaScript function for rendering the chart.

--- a/lib/google_visualr/interactive/annotation_chart.rb
+++ b/lib/google_visualr/interactive/annotation_chart.rb
@@ -1,0 +1,11 @@
+module GoogleVisualr
+  module Interactive
+
+    # https://developers.google.com/chart/interactive/docs/gallery/annotationchart
+    class AnnotationChart < BaseChart
+      # For Configuration Options, please refer to:
+      # https://developers.google.com/chart/interactive/docs/gallery/annotationchart#configuration-options
+    end
+
+  end
+end

--- a/lib/google_visualr/interactive/calendar.rb
+++ b/lib/google_visualr/interactive/calendar.rb
@@ -1,0 +1,11 @@
+module GoogleVisualr
+  module Interactive
+
+    # https://developers.google.com/chart/interactive/docs/gallery/calendar
+    class Calendar < BaseChart
+      # For Configuration Options, please refer to:
+      # https://developers.google.com/chart/interactive/docs/gallery/calendar#configuration-options
+    end
+
+  end
+end

--- a/lib/google_visualr/interactive/gantt_chart.rb
+++ b/lib/google_visualr/interactive/gantt_chart.rb
@@ -1,0 +1,16 @@
+module GoogleVisualr
+  module Interactive
+
+    # https://developers.google.com/chart/interactive/docs/gallery/ganttchart
+    class GanttChart < BaseChart
+
+      def package_name
+        "gantt"
+      end
+
+      # For Configuration Options, please refer to:
+      # https://developers.google.com/chart/interactive/docs/gallery/ganttchart#configuration-options
+    end
+
+  end
+end

--- a/lib/google_visualr/interactive/sankey.rb
+++ b/lib/google_visualr/interactive/sankey.rb
@@ -1,0 +1,11 @@
+module GoogleVisualr
+  module Interactive
+
+    # https://developers.google.com/chart/interactive/docs/gallery/sankey
+    class Sankey < BaseChart
+      # For Configuration Options, please refer to:
+      # https://developers.google.com/chart/interactive/docs/gallery/sankey#configuration-options
+    end
+
+  end
+end

--- a/lib/google_visualr/interactive/word_tree.rb
+++ b/lib/google_visualr/interactive/word_tree.rb
@@ -1,0 +1,11 @@
+module GoogleVisualr
+  module Interactive
+
+    # https://developers.google.com/chart/interactive/docs/gallery/wordtree
+    class WordTree < BaseChart
+      # For Configuration Options, please refer to:
+      # https://developers.google.com/chart/interactive/docs/gallery/wordtree#a-simple-example
+    end
+
+  end
+end

--- a/spec/google_visualr/base_chart_spec.rb
+++ b/spec/google_visualr/base_chart_spec.rb
@@ -15,9 +15,18 @@ describe GoogleVisualr::BaseChart do
       @chart.options.should    == { "legend" => "Test Chart", "width" => 800, "is3D" => true }
     end
 
-    it "accepts material and version attributes" do
-      @chart = GoogleVisualr::BaseChart.new(@dt, { :version => "1.1", :material => true })
+    it "accepts version attribute" do
+      @chart = GoogleVisualr::BaseChart.new(@dt, version: "1.1")
       @chart.version.should    == "1.1"
+    end
+
+    it "accepts language attribute" do
+      @chart = GoogleVisualr::BaseChart.new(@dt, language: "ja")
+      @chart.language.should    == "ja"
+    end
+
+    it "accepts material attribute" do
+      @chart = GoogleVisualr::BaseChart.new(@dt, material: true)
       @chart.material.should   == true
     end
   end
@@ -87,6 +96,13 @@ describe GoogleVisualr::BaseChart do
       js = @chart.to_js("body")
       js.should == base_chart_js("body")
       js.should include("<script")
+    end
+
+    it "generates JS of a different locale" do
+      @chart.language = "ja"
+
+      js = @chart.to_js("body")
+      js.should == base_chart_js("body", "ja")
     end
 
     it "generates JS with listeners" do

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -17,23 +17,23 @@ def base_chart(data_table = data_table())
   GoogleVisualr::BaseChart.new(data_table, { :legend => "Test Chart", :width => 800, :is3D => true })
 end
 
-def base_chart_js_without_script_tag(div_class="div_class")
-  js =  "\n  google.load('visualization','1.0', {packages: ['basechart'], callback: draw_#{div_class}});"
+def base_chart_js_without_script_tag(div_class = "div_class", language = "en")
+  js =  "\n  google.load('visualization', '1.0', {packages: ['basechart'], language: '#{language}', callback: draw_#{div_class}});"
   js << "\n  function draw_#{div_class}() {"
   js << "\n    var data_table = new google.visualization.DataTable();data_table.addColumn({\"type\":\"string\",\"label\":\"Year\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Sales\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Expenses\"});data_table.addRow([{v: \"2004\"}, {v: 1000}, {v: 400}]);data_table.addRow([{v: \"2005\"}, {v: 1200}, {v: 450}]);data_table.addRow([{v: \"2006\"}, {v: 1500}, {v: 600}]);data_table.addRow([{v: \"2007\"}, {v: 800}, {v: 500}]);\n    var chart = new google.visualization.BaseChart(document.getElementById('#{div_class}'));"
   js << "\n    chart.draw(data_table, {legend: \"Test Chart\", width: 800, is3D: true});"
   js << "\n  };"
 end
 
-def base_chart_js(div_class="div_class")
+def base_chart_js(div_class = "div_class", language = "en")
   js =  "\n<script type='text/javascript'>"
-  js << base_chart_js_without_script_tag(div_class)
+  js << base_chart_js_without_script_tag(div_class, language)
   js << "\n</script>"
 end
 
-def base_chart_with_listener_js(div_class="div_class")
+def base_chart_with_listener_js(div_class = "div_class")
   js =  "\n<script type='text/javascript'>"
-  js << "\n  google.load('visualization','1.0', {packages: ['basechart'], callback: draw_#{div_class}});"
+  js << "\n  google.load('visualization', '1.0', {packages: ['basechart'], language: 'en', callback: draw_#{div_class}});"
   js << "\n  function draw_#{div_class}() {"
   js << "\n    var data_table = new google.visualization.DataTable();data_table.addColumn({\"type\":\"string\",\"label\":\"Year\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Sales\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Expenses\"});data_table.addRow([{v: \"2004\"}, {v: 1000}, {v: 400}]);data_table.addRow([{v: \"2005\"}, {v: 1200}, {v: 450}]);data_table.addRow([{v: \"2006\"}, {v: 1500}, {v: 600}]);data_table.addRow([{v: \"2007\"}, {v: 800}, {v: 500}]);\n    var chart = new google.visualization.BaseChart(document.getElementById('#{div_class}'));"
   js << "\n    google.visualization.events.addListener(chart, 'select', function() {test_event(chart);});"
@@ -44,7 +44,7 @@ end
 
 def material_chart(div_class = "div_class")
   js =  "\n<script type='text/javascript'>"
-  js << "\n  google.load('visualization','1.0', {packages: ['basechart'], callback: draw_#{div_class}});"
+  js << "\n  google.load('visualization', '1.0', {packages: ['basechart'], language: 'en', callback: draw_#{div_class}});"
   js << "\n  function draw_#{div_class}() {"
   js << "\n    var data_table = new google.visualization.DataTable();data_table.addColumn({\"type\":\"string\",\"label\":\"Year\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Sales\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Expenses\"});data_table.addRow([{v: \"2004\"}, {v: 1000}, {v: 400}]);data_table.addRow([{v: \"2005\"}, {v: 1200}, {v: 450}]);data_table.addRow([{v: \"2006\"}, {v: 1500}, {v: 600}]);data_table.addRow([{v: \"2007\"}, {v: 800}, {v: 500}]);\n    var chart = new google.charts.Base(document.getElementById('#{div_class}'));"
   js << "\n    chart.draw(data_table, {legend: \"Test Chart\", width: 800, is3D: true});"


### PR DESCRIPTION
https://google-developers.appspot.com/chart/interactive/docs/library_loading_enhancements#loadwithlocale

Built on top of #95.

To have charts of a different locale, pass `language` option to the chart:

```
  opts   = { 
    :width => 400, :height => 240, 
    :title => 'Company Performance', 
    vAxis: {title: 'Year', titleTextStyle: {color: 'red'}},
    language: 'ja'
  }
    @chart = GoogleVisualr::Interactive::BarChart.new(data_table, opts)
```

Fixes: #76 