### PR TITLE
Don't force english language

### DIFF
--- a/lib/google_visualr/base_chart.rb
+++ b/lib/google_visualr/base_chart.rb
@@ -11,7 +11,7 @@ module GoogleVisualr
       @data_table  = data_table
       @listeners   = []
       @version     = options.delete(:version)  || DEFAULT_VERSION
-      @language    = options.delete(:language) || "en"
+      @language    = options.delete(:language)
       @material    = options.delete(:material) || false
       send(:options=, options)
     end
@@ -74,7 +74,9 @@ module GoogleVisualr
     # Parameters:
     #  *div_id            [Required] The ID of the DIV element that the Google Chart should be rendered in.
     def load_js(element_id)
-      "\n  google.load('visualization', '#{version}', {packages: ['#{package_name}'], language: '#{language}', callback: #{chart_function_name(element_id)}});"
+      language_opt = ", language: '#{language}'" if language
+
+      "\n  google.load('visualization', '#{version}', {packages: ['#{package_name}']#{language_opt}, callback: #{chart_function_name(element_id)}});"
     end
 
     # Generates JavaScript function for rendering the chart.

--- a/spec/google_visualr/base_chart_spec.rb
+++ b/spec/google_visualr/base_chart_spec.rb
@@ -13,6 +13,7 @@ describe GoogleVisualr::BaseChart do
       @chart.version.should    == GoogleVisualr::BaseChart::DEFAULT_VERSION
       @chart.material.should   == false
       @chart.options.should    == { "legend" => "Test Chart", "width" => 800, "is3D" => true }
+      @chart.language.should   == nil
     end
 
     it "accepts version attribute" do
@@ -96,6 +97,11 @@ describe GoogleVisualr::BaseChart do
       js = @chart.to_js("body")
       js.should == base_chart_js("body")
       js.should include("<script")
+    end
+
+    it "generates JS without any locale as default" do
+      js = @chart.to_js("body")
+      js.should == base_chart_js("body", nil)
     end
 
     it "generates JS of a different locale" do

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -17,15 +17,17 @@ def base_chart(data_table = data_table())
   GoogleVisualr::BaseChart.new(data_table, { :legend => "Test Chart", :width => 800, :is3D => true })
 end
 
-def base_chart_js_without_script_tag(div_class = "div_class", language = "en")
-  js =  "\n  google.load('visualization', '1.0', {packages: ['basechart'], language: '#{language}', callback: draw_#{div_class}});"
+def base_chart_js_without_script_tag(div_class = "div_class", language = nil)
+  language_opt = ", language: '#{language}'" if language
+
+  js =  "\n  google.load('visualization', '1.0', {packages: ['basechart']#{language_opt}, callback: draw_#{div_class}});"
   js << "\n  function draw_#{div_class}() {"
   js << "\n    var data_table = new google.visualization.DataTable();data_table.addColumn({\"type\":\"string\",\"label\":\"Year\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Sales\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Expenses\"});data_table.addRow([{v: \"2004\"}, {v: 1000}, {v: 400}]);data_table.addRow([{v: \"2005\"}, {v: 1200}, {v: 450}]);data_table.addRow([{v: \"2006\"}, {v: 1500}, {v: 600}]);data_table.addRow([{v: \"2007\"}, {v: 800}, {v: 500}]);\n    var chart = new google.visualization.BaseChart(document.getElementById('#{div_class}'));"
   js << "\n    chart.draw(data_table, {legend: \"Test Chart\", width: 800, is3D: true});"
   js << "\n  };"
 end
 
-def base_chart_js(div_class = "div_class", language = "en")
+def base_chart_js(div_class = "div_class", language = nil)
   js =  "\n<script type='text/javascript'>"
   js << base_chart_js_without_script_tag(div_class, language)
   js << "\n</script>"
@@ -33,7 +35,7 @@ end
 
 def base_chart_with_listener_js(div_class = "div_class")
   js =  "\n<script type='text/javascript'>"
-  js << "\n  google.load('visualization', '1.0', {packages: ['basechart'], language: 'en', callback: draw_#{div_class}});"
+  js << "\n  google.load('visualization', '1.0', {packages: ['basechart'], callback: draw_#{div_class}});"
   js << "\n  function draw_#{div_class}() {"
   js << "\n    var data_table = new google.visualization.DataTable();data_table.addColumn({\"type\":\"string\",\"label\":\"Year\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Sales\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Expenses\"});data_table.addRow([{v: \"2004\"}, {v: 1000}, {v: 400}]);data_table.addRow([{v: \"2005\"}, {v: 1200}, {v: 450}]);data_table.addRow([{v: \"2006\"}, {v: 1500}, {v: 600}]);data_table.addRow([{v: \"2007\"}, {v: 800}, {v: 500}]);\n    var chart = new google.visualization.BaseChart(document.getElementById('#{div_class}'));"
   js << "\n    google.visualization.events.addListener(chart, 'select', function() {test_event(chart);});"
@@ -44,7 +46,7 @@ end
 
 def material_chart(div_class = "div_class")
   js =  "\n<script type='text/javascript'>"
-  js << "\n  google.load('visualization', '1.0', {packages: ['basechart'], language: 'en', callback: draw_#{div_class}});"
+  js << "\n  google.load('visualization', '1.0', {packages: ['basechart'], callback: draw_#{div_class}});"
   js << "\n  function draw_#{div_class}() {"
   js << "\n    var data_table = new google.visualization.DataTable();data_table.addColumn({\"type\":\"string\",\"label\":\"Year\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Sales\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Expenses\"});data_table.addRow([{v: \"2004\"}, {v: 1000}, {v: 400}]);data_table.addRow([{v: \"2005\"}, {v: 1200}, {v: 450}]);data_table.addRow([{v: \"2006\"}, {v: 1500}, {v: 600}]);data_table.addRow([{v: \"2007\"}, {v: 800}, {v: 500}]);\n    var chart = new google.charts.Base(document.getElementById('#{div_class}'));"
   js << "\n    chart.draw(data_table, {legend: \"Test Chart\", width: 800, is3D: true});"


### PR DESCRIPTION
In #96, the `language`option was introduced. Unfortunately, it forces the language to be english, if the option is not set. This breaks the browser detection. Please see the [docs](https://developers.google.com/chart/interactive/docs/library_loading_enhancements#loadwithlocale):

    By default, the Google Chart libraries are loaded with the locale specified by the browser

This PR removes the fallback