### PR TITLE
Fix broken options for material charts

### DIFF
--- a/lib/google_visualr/base_chart.rb
+++ b/lib/google_visualr/base_chart.rb
@@ -91,7 +91,11 @@ module GoogleVisualr
       @listeners.each do |listener|
         js << "\n    google.visualization.events.addListener(chart, '#{listener[:event]}', #{listener[:callback]});"
       end
-      js << "\n    chart.draw(data_table, #{js_parameters(@options)});"
+      if @material
+        js << "\n    chart.draw(data_table, google.charts.Line.convertOptions(#{js_parameters(@options)}));"
+      else
+        js << "\n    chart.draw(data_table, #{js_parameters(@options)});"
+      end
       js << "\n  };"
       js
     end

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -49,7 +49,7 @@ def material_chart(div_class = "div_class")
   js << "\n  google.load('visualization', '1.0', {packages: ['basechart'], callback: draw_#{div_class}});"
   js << "\n  function draw_#{div_class}() {"
   js << "\n    var data_table = new google.visualization.DataTable();data_table.addColumn({\"type\":\"string\",\"label\":\"Year\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Sales\"});data_table.addColumn({\"type\":\"number\",\"label\":\"Expenses\"});data_table.addRow([{v: \"2004\"}, {v: 1000}, {v: 400}]);data_table.addRow([{v: \"2005\"}, {v: 1200}, {v: 450}]);data_table.addRow([{v: \"2006\"}, {v: 1500}, {v: 600}]);data_table.addRow([{v: \"2007\"}, {v: 800}, {v: 500}]);\n    var chart = new google.charts.Base(document.getElementById('#{div_class}'));"
-  js << "\n    chart.draw(data_table, {legend: \"Test Chart\", width: 800, is3D: true});"
+  js << "\n    chart.draw(data_table, google.charts.Line.convertOptions({legend: \"Test Chart\", width: 800, is3D: true}));"
   js << "\n  };"
   js << "\n</script>"
 end


### PR DESCRIPTION
This fixes several broken options for material charts.

https://developers.google.com/chart/interactive/docs/gallery/linechart?csw=1#creating-material-line-charts says:

The Material Charts are in beta. The appearance and interactivity are
largely final, but the way options are declared is not. If you are
converting a Classic Line Chart to a Material Line Chart, you'll want to
replace this line:

chart.draw(data, options);

...with this:

chart.draw(data, google.charts.Line.convertOptions(options));