### PR TITLE
Add support for attribute 'p' in columns.

### DIFF
--- a/lib/google_visualr/data_table.rb
+++ b/lib/google_visualr/data_table.rb
@@ -78,18 +78,19 @@ module GoogleVisualr
     #   * id              [Optional] A unique (basic alphanumeric) string ID of the column. Be careful not to choose a JavaScript keyword. Example: id:'col_1'
     #   * role            [Optional] A string value that describes the purpose of the data in that column. Example, a column might hold data describing tooltip text, data point annotations, or uncertainty indicators.
     #   * pattern         [Optional] A number (or date) format string specifying how to display the column value; used in conjunction with role.
-    def new_column(type, label=nil, id =nil, role=nil, pattern=nil)
-      column = { :type => type, :label => label, :id => id, :role => role, :pattern => pattern }.reject { |key, value| value.nil? }
+    #   * p               [Optional] A hash of custom values applied to the cell. These values can be of any type that responds to #to_json. If your visualization supports any cell-level properties, it will describe them; otherwise, this property will be ignored.
+    def new_column(type, label=nil, id =nil, role=nil, pattern=nil, p=nil)
+      column = { :type => type, :label => label, :id => id, :role => role, :pattern => pattern, :p => p }.reject { |key, value| value.nil? }
       @cols << column
     end
 
     # Adds multiple columns to the data_table.
     #
     # Parameters:
-    #   * columns         [Required] An array of column objects {:type, :label, :id, :role, :pattern}. Calls new_column for each column object.
+    #   * columns         [Required] An array of column objects {:type, :label, :id, :role, :pattern, :p}. Calls new_column for each column object.
     def new_columns(columns)
       columns.each do |column|
-        new_column(column[:type], column[:label], column[:id], column[:role], column[:pattern])
+        new_column(column[:type], column[:label], column[:id], column[:role], column[:pattern], column[:p])
       end
     end
 

--- a/spec/google_visualr/data_table_spec.rb
+++ b/spec/google_visualr/data_table_spec.rb
@@ -58,6 +58,11 @@ describe GoogleVisualr::DataTable do
       dt.new_column('string', nil, nil, 'interval', 'pattern')
       dt.cols.first.should == {:type => 'string', :role => 'interval', :pattern => 'pattern'}
     end
+
+    it "initializes a new column with custom 'p' param" do
+      dt.new_column('string', nil, nil, 'role', nil, {:my_property => 'value'})
+      dt.cols.first.should == {:type => 'string', :role => 'role', :p => {:my_property => 'value'}}
+    end
   end
 
   describe "new_columns" do
@@ -65,13 +70,15 @@ describe GoogleVisualr::DataTable do
       columns = [
         {:id => 'A', :label => 'NEW A', :type => 'string'},
         {:id => 'B', :label => 'NEW B', :type => 'string'},
-        {:type => 'string', :role => 'interval', :pattern => 'pattern'}
+        {:type => 'string', :role => 'interval', :pattern => 'pattern'},
+        {:type => 'string', :role => 'tooltip', :p => {:html => true}}
       ]
 
       dt.new_columns(columns)
       dt.cols[0].should == columns[0]
       dt.cols[1].should == columns[1]
       dt.cols[2].should == columns[2]
+      dt.cols[3].should == columns[3]
     end
   end
 


### PR DESCRIPTION
Columns now have another optional attribute _p_, as specified here: [https://developers.google.com/chart/interactive/docs/reference#methods](url) (search for 'cols Property')
 
The _p_ attribute is the way to define all sorts of visualization-specific custom behavior. My actual need is to define a tooltip column as HTML (see [https://developers.google.com/chart/interactive/docs/customizing_tooltip_content#customizing-html-content](url)). 