### PR TITLE
Fixed Railtie to only load helper for UI controller

### DIFF
--- a/lib/google_visualr/app/railtie.rb
+++ b/lib/google_visualr/app/railtie.rb
@@ -7,7 +7,7 @@ module GoogleVisualr
     class Railtie < ::Rails::Railtie
 
       initializer "google_visualr" do
-        ActiveSupport.on_load(:action_controller) do
+        ActiveSupport.on_load(:action_controller_base) do
           include GoogleVisualr::Rails::ViewHelper
         end
       end


### PR DESCRIPTION
## Overview

Necessary to prevent the following error when a Rails application is
initialized and uses the `ActionController::API` for a base class:

    NoMethodError:
      undefined method `helper_method' for ActionController::API:Class
    # $HOME/.gem/ruby/2.7.3/gems/google_visualr-2.5.1/lib/
      google_visualr/app/helpers/view_helper.rb:7:in `block in
      <module:ViewHelper>'

Normally, when configuring Rails, you can specify if your application
is API or UI only (UI is the default) and Rails will auto-filter
initializers which don't support the one or the other. In my case, I'm
working with a Rails app that is a hybrid of UI and API functionality.
Unfortunately, the `:action_controller` hook is a superset hook which
causes issues. Here's a better illustration:

- `:action_controller` - `ApplicationController` and
  `ActionController::API`.
- `:action_controller_base` - `ApplicationController` only.
- `:action_controller_api` - `ActionController::API` only.

This is why applying this fix ensures the Google view helper isn't
loaded for API purposes. 😉

## Notes

I'm afraid I wasn't able to write a spec for this because the Bundler and Appraisal gems are quite outdated on this project. If I had more time, I'd fix that too but wanted to get this up for review in case there is interest and of help to others.